### PR TITLE
Add frequency_penalty and presence_penalty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -295,6 +295,8 @@ pub struct GenOpts {
     pub seed: Option<u64>,
     pub json_schema: Option<serde_json::Value>,
     pub json_schema_strict: Option<bool>,
+    pub frequency_penalty: Option<f32>,
+    pub presence_penalty: Option<f32>,
 }
 
 impl GenOpts {
@@ -335,6 +337,8 @@ impl Into<SeqGenReq> for GenOpts {
             seed: self.seed,
             json_schema: self.json_schema,
             json_schema_strict: self.json_schema_strict,
+            frequency_penalty: self.frequency_penalty,
+            presence_penalty: self.presence_penalty,
             ..Default::default()
         }
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -229,6 +229,10 @@ pub struct SeqGenReq {
     pub json_schema: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub json_schema_strict: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/python.rs
+++ b/src/python.rs
@@ -151,7 +151,7 @@ impl PyBlockingSeq {
     }
 
     #[pyo3(
-        text_signature = "($self, /, *, role=None, stop_strings=None, max_length=None, max_tokens=None, hidden=None, temperature=None, top_p=None, top_k=None, repeat_penalty=None, seed=None)",
+        text_signature = "($self, /, *, role=None, stop_strings=None, max_length=None, max_tokens=None, hidden=None, temperature=None, top_p=None, top_k=None, repeat_penalty=None, seed=None, frequency_penalty=None, presence_penalty=None)",
         signature = (
             role=None,
             stop_strings=None,
@@ -162,7 +162,9 @@ impl PyBlockingSeq {
             top_p=None,
             top_k=None,
             repeat_penalty=None,
-            seed=None
+            seed=None,
+            frequency_penalty=None,
+            presence_penalty=None
         )
     )]
     pub fn gen_text(
@@ -177,6 +179,8 @@ impl PyBlockingSeq {
         top_k: Option<i32>,
         repeat_penalty: Option<f32>,
         seed: Option<u64>,
+        frequency_penalty: Option<f32>,
+        presence_penalty: Option<f32>,
     ) -> PyResult<String> {
         let seq = self.inner.clone();
 
@@ -193,6 +197,8 @@ impl PyBlockingSeq {
                     top_k,
                     repeat_penalty,
                     seed,
+                    frequency_penalty,
+                    presence_penalty,
                 );
                 let stream = seq.generate(Some(opts)).await?;
                 stream.text().await
@@ -528,6 +534,8 @@ fn build_gen_opts(
     top_k: Option<i32>,
     repeat_penalty: Option<f32>,
     seed: Option<u64>,
+    frequency_penalty: Option<f32>,
+    presence_penalty: Option<f32>,
 ) -> GenOpts {
     let mut opts = GenOpts::default();
     opts.role = role.map(|r| r.to_string());
@@ -540,6 +548,8 @@ fn build_gen_opts(
     opts.top_k = top_k;
     opts.repeat_penalty = repeat_penalty;
     opts.seed = seed;
+    opts.frequency_penalty = frequency_penalty;
+    opts.presence_penalty = presence_penalty;
     opts
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional frequency_penalty and presence_penalty parameters for text generation, letting users fine‑tune repetition and topic persistence.
  * Python API updated to accept these optional parameters in generation calls.

* **Chores**
  * Package version bumped to reflect the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->