### PR TITLE
Support for tool call streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "modelsocket"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -39,6 +39,7 @@ pub enum SeqCommand {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "event")]
+#[non_exhaustive]
 pub enum MSEvent {
     SeqOpened {
         seq_id: String,
@@ -70,6 +71,30 @@ pub enum MSEvent {
         seq_id: String,
         cid: String,
         tool_calls: Vec<SeqToolCall>,
+    },
+    SeqToolCallStart {
+        seq_id: String,
+        cid: String,
+        index: u32,
+        name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    SeqToolCallArgsChunk {
+        seq_id: String,
+        cid: String,
+        index: u32,
+        fragment: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
+    SeqToolCallAborted {
+        seq_id: String,
+        cid: String,
+        index: u32,
+        reason: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
     },
     SeqState {
         seq_id: String,
@@ -103,6 +128,9 @@ impl MSEvent {
             MSEvent::SeqForkFinish { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqText { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqToolCall { cid, .. } => Some(cid.as_str()),
+            MSEvent::SeqToolCallStart { cid, .. } => Some(cid.as_str()),
+            MSEvent::SeqToolCallArgsChunk { cid, .. } => Some(cid.as_str()),
+            MSEvent::SeqToolCallAborted { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqClosed { cid, .. } => cid.as_ref().map(|s| s.as_str()),
             MSEvent::Error { cid, .. } => cid.as_ref().map(|s| s.as_str()),
             _ => None,
@@ -117,6 +145,9 @@ impl MSEvent {
             MSEvent::SeqForkFinish { .. } => "seq_fork_finish",
             MSEvent::SeqText { .. } => "seq_text",
             MSEvent::SeqToolCall { .. } => "seq_tool_call",
+            MSEvent::SeqToolCallStart { .. } => "seq_tool_call_start",
+            MSEvent::SeqToolCallArgsChunk { .. } => "seq_tool_call_args_chunk",
+            MSEvent::SeqToolCallAborted { .. } => "seq_tool_call_aborted",
             MSEvent::SeqClosed { .. } => "seq_closed",
             MSEvent::SeqState { .. } => "seq_state",
             MSEvent::Error { .. } => "error",
@@ -131,6 +162,9 @@ impl MSEvent {
             MSEvent::SeqForkFinish { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqText { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqToolCall { seq_id, .. } => Some(seq_id.as_str()),
+            MSEvent::SeqToolCallStart { seq_id, .. } => Some(seq_id.as_str()),
+            MSEvent::SeqToolCallArgsChunk { seq_id, .. } => Some(seq_id.as_str()),
+            MSEvent::SeqToolCallAborted { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqState { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqClosed { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::Error { seq_id, .. } => seq_id.as_ref().map(|s| s.as_str()),
@@ -263,6 +297,10 @@ pub struct SeqToolCall {
     pub id: Option<String>,
     pub name: String,
     pub args: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -298,8 +298,6 @@ pub struct SeqToolCall {
     pub name: String,
     pub args: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub index: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -77,7 +77,6 @@ pub enum MSEvent {
         cid: String,
         index: u32,
         name: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         id: Option<String>,
     },
     SeqToolCallArgsChunk {
@@ -85,15 +84,19 @@ pub enum MSEvent {
         cid: String,
         index: u32,
         fragment: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         id: Option<String>,
+    },
+    SeqToolCallEnd {
+        seq_id: String,
+        cid: String,
+        index: u32,
+        args: String
     },
     SeqToolCallAborted {
         seq_id: String,
         cid: String,
         index: u32,
         reason: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         id: Option<String>,
     },
     SeqState {
@@ -130,6 +133,7 @@ impl MSEvent {
             MSEvent::SeqToolCall { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqToolCallStart { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqToolCallArgsChunk { cid, .. } => Some(cid.as_str()),
+            MSEvent::SeqToolCallEnd { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqToolCallAborted { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqClosed { cid, .. } => cid.as_ref().map(|s| s.as_str()),
             MSEvent::Error { cid, .. } => cid.as_ref().map(|s| s.as_str()),
@@ -147,6 +151,7 @@ impl MSEvent {
             MSEvent::SeqToolCall { .. } => "seq_tool_call",
             MSEvent::SeqToolCallStart { .. } => "seq_tool_call_start",
             MSEvent::SeqToolCallArgsChunk { .. } => "seq_tool_call_args_chunk",
+            MSEvent::SeqToolCallEnd { .. } => "seq_tool_call_end",
             MSEvent::SeqToolCallAborted { .. } => "seq_tool_call_aborted",
             MSEvent::SeqClosed { .. } => "seq_closed",
             MSEvent::SeqState { .. } => "seq_state",
@@ -164,6 +169,7 @@ impl MSEvent {
             MSEvent::SeqToolCall { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqToolCallStart { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqToolCallArgsChunk { seq_id, .. } => Some(seq_id.as_str()),
+            MSEvent::SeqToolCallEnd { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqToolCallAborted { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqState { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqClosed { seq_id, .. } => Some(seq_id.as_str()),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -297,8 +297,6 @@ pub struct SeqToolCall {
     pub id: Option<String>,
     pub name: String,
     pub args: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/python.rs
+++ b/src/python.rs
@@ -207,7 +207,7 @@ impl PyBlockingSeq {
     }
 
     #[pyo3(
-        text_signature = "($self, /, *, role=None, stop_strings=None, max_length=None, max_tokens=None, hidden=None, temperature=None, top_p=None, top_k=None, repeat_penalty=None, seed=None)",
+        text_signature = "($self, /, *, role=None, stop_strings=None, max_length=None, max_tokens=None, hidden=None, temperature=None, top_p=None, top_k=None, repeat_penalty=None, seed=None, frequency_penalty=None, presence_penalty=None)",
         signature = (
             role=None,
             stop_strings=None,
@@ -218,7 +218,9 @@ impl PyBlockingSeq {
             top_p=None,
             top_k=None,
             repeat_penalty=None,
-            seed=None
+            seed=None,
+            frequency_penalty=None,
+            presence_penalty=None
         )
     )]
     pub fn gen_text_and_tokens(
@@ -233,6 +235,8 @@ impl PyBlockingSeq {
         top_k: Option<i32>,
         repeat_penalty: Option<f32>,
         seed: Option<u64>,
+        frequency_penalty: Option<f32>,
+        presence_penalty: Option<f32>,
     ) -> PyResult<(String, Vec<u32>)> {
         let seq = self.inner.clone();
 
@@ -249,6 +253,8 @@ impl PyBlockingSeq {
                     top_k,
                     repeat_penalty,
                     seed,
+                    frequency_penalty,
+                    presence_penalty,
                 );
                 let stream = seq.generate(Some(opts)).await?;
                 stream.text_and_tokens().await
@@ -257,7 +263,7 @@ impl PyBlockingSeq {
     }
 
     #[pyo3(
-        text_signature = "($self, /, *, role=None, stop_strings=None, max_length=None, max_tokens=None, hidden=None, temperature=None, top_p=None, top_k=None, repeat_penalty=None, seed=None)",
+        text_signature = "($self, /, *, role=None, stop_strings=None, max_length=None, max_tokens=None, hidden=None, temperature=None, top_p=None, top_k=None, repeat_penalty=None, seed=None, frequency_penalty=None, presence_penalty=None)",
         signature = (
             role=None,
             stop_strings=None,
@@ -268,7 +274,9 @@ impl PyBlockingSeq {
             top_p=None,
             top_k=None,
             repeat_penalty=None,
-            seed=None
+            seed=None,
+            frequency_penalty=None,
+            presence_penalty=None
         )
     )]
     pub fn gen_text_stream(
@@ -284,6 +292,8 @@ impl PyBlockingSeq {
         top_k: Option<i32>,
         repeat_penalty: Option<f32>,
         seed: Option<u64>,
+        frequency_penalty: Option<f32>,
+        presence_penalty: Option<f32>,
     ) -> PyResult<Py<PyBlockingGenStream>> {
         let seq = self.inner.clone();
 
@@ -299,6 +309,8 @@ impl PyBlockingSeq {
                 top_k,
                 repeat_penalty,
                 seed,
+                frequency_penalty,
+                presence_penalty,
             );
             seq.generate(Some(opts)).await
         })?;


### PR DESCRIPTION
Effectively, a ModelSocket representation of OpenAI's tool call streaming as described here: https://developers.openai.com/api/docs/guides/function-calling#streaming.

Flow:

```
SeqToolCallStart -> SeqToolCallArgsChunk[1..] -> SeqToolCall (existing)
SeqToolCallStart -> SeqToolCallArgsChunk[1..] -> SeqToolCallAborted (or sooner)
```

Similar to OpenAI, `index` is used to track any potential parallel tool call generations to ensure args can be tied back to the appropriate function

Clean/standard session:

```json
{"kind":"event","event_type":"seq_tool_call_start","cmd_id":"gen","seq_id":"seq_x","index":0,"name":"whois"}

  {"kind":"event","event_type":"seq_tool_call_args_chunk","cmd_id":"gen","seq_id":"seq_x","index":0,"fragment":"{\"domain\":\""}
  {"kind":"event","event_type":"seq_tool_call_args_chunk","cmd_id":"gen","seq_id":"seq_x","index":0,"fragment":"mix"}
  {"kind":"event","event_type":"seq_tool_call_args_chunk","cmd_id":"gen","seq_id":"seq_x","index":0,"fragment":"layer.ai\",\"verbose\":true}"}

{"kind":"event","event_type":"seq_tool_call_end","cmd_id":"gen","seq_id":"seq_x","index":0,"args":"... constructed args..."}

// existing seq_tool_call with "tool_calls": [...]
```

An abort looks something like:

```json
{"kind":"event","event_type":"seq_tool_call_start","cmd_id":"gen","seq_id":"seq_x","index":0,"name":"whois"}

  {"kind":"event","event_type":"seq_tool_call_args_chunk","cmd_id":"gen","seq_id":"seq_x","index":0,"fragment":"{\"domain\":\""}
  {"kind":"event","event_type":"seq_tool_call_args_chunk","cmd_id":"gen","seq_id":"seq_x","index":0,"fragment":"mix"}

{"kind":"event","event_type":"seq_tool_call_aborted","cmd_id":"gen","seq_id":"seq_x","index":0,"reason":"eos_before_complete"}
```