### PR TITLE
add tool call ID to SeqToolCall protocol struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "modelsocket"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "modelsocket"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/src/client/tools.rs
+++ b/src/client/tools.rs
@@ -51,6 +51,7 @@ impl SimpleToolbox {
         for call in calls {
             let result = self.call(call.name.as_str(), call.args.as_str()).await?;
             results.push(ToolResult {
+                id: call.id.clone(),
                 name: call.name.clone(),
                 result,
             });

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -239,6 +239,8 @@ pub struct SeqGenReq {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub name: String,
     pub result: String,
 }
@@ -265,7 +267,7 @@ pub struct SeqToolCall {
 
 #[cfg(test)]
 mod tests {
-    use super::{MSEvent, SeqToolCall};
+    use super::{MSEvent, SeqToolCall, SeqToolReturnReq, ToolResult};
 
     #[test]
     fn seq_tool_call_deserializes_without_id() {
@@ -323,5 +325,57 @@ mod tests {
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].id, None);
         assert_eq!(tool_calls[0].name, "search");
+    }
+
+    #[test]
+    fn tool_result_deserializes_without_id() {
+        let json = r#"{"name":"search","result":"{\"hits\":3}"}"#;
+        let result: ToolResult = serde_json::from_str(json).unwrap();
+
+        assert_eq!(result.id, None);
+        assert_eq!(result.name, "search");
+        assert_eq!(result.result, r#"{"hits":3}"#);
+    }
+
+    #[test]
+    fn tool_result_round_trips_with_id() {
+        let result = ToolResult {
+            id: Some("functions.search:0".to_string()),
+            name: "search".to_string(),
+            result: r#"{"hits":3}"#.to_string(),
+        };
+
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains(r#""id":"functions.search:0""#));
+
+        let round_trip: ToolResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip.id, Some("functions.search:0".to_string()));
+        assert_eq!(round_trip.name, "search");
+        assert_eq!(round_trip.result, r#"{"hits":3}"#);
+    }
+
+    #[test]
+    fn tool_result_omits_absent_id() {
+        let result = ToolResult {
+            id: None,
+            name: "search".to_string(),
+            result: r#"{"hits":3}"#.to_string(),
+        };
+
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(!json.contains(r#""id""#));
+    }
+
+    #[test]
+    fn tool_return_deserializes_legacy_results_without_id() {
+        let json = r#"{
+            "results":[{"name":"search","result":"{\"hits\":3}"}],
+            "gen_opts":{}
+        }"#;
+
+        let req: SeqToolReturnReq = serde_json::from_str(json).unwrap();
+        assert_eq!(req.results.len(), 1);
+        assert_eq!(req.results[0].id, None);
+        assert_eq!(req.results[0].name, "search");
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -257,6 +257,71 @@ pub struct SeqToolReturnReq {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SeqToolCall {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub name: String,
     pub args: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MSEvent, SeqToolCall};
+
+    #[test]
+    fn seq_tool_call_deserializes_without_id() {
+        let json = r#"{"name":"search","args":"{\"q\":\"hello\"}"}"#;
+        let call: SeqToolCall = serde_json::from_str(json).unwrap();
+
+        assert_eq!(call.id, None);
+        assert_eq!(call.name, "search");
+        assert_eq!(call.args, r#"{"q":"hello"}"#);
+    }
+
+    #[test]
+    fn seq_tool_call_round_trips_with_id() {
+        let call = SeqToolCall {
+            id: Some("functions.search:0".to_string()),
+            name: "search".to_string(),
+            args: r#"{"q":"hello"}"#.to_string(),
+        };
+
+        let json = serde_json::to_string(&call).unwrap();
+        assert!(json.contains(r#""id":"functions.search:0""#));
+
+        let round_trip: SeqToolCall = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip.id, Some("functions.search:0".to_string()));
+        assert_eq!(round_trip.name, "search");
+        assert_eq!(round_trip.args, r#"{"q":"hello"}"#);
+    }
+
+    #[test]
+    fn seq_tool_call_omits_absent_id() {
+        let call = SeqToolCall {
+            id: None,
+            name: "search".to_string(),
+            args: r#"{"q":"hello"}"#.to_string(),
+        };
+
+        let json = serde_json::to_string(&call).unwrap();
+        assert!(!json.contains(r#""id""#));
+    }
+
+    #[test]
+    fn seq_tool_call_event_deserializes_legacy_payload() {
+        let json = r#"{
+            "event":"seq_tool_call",
+            "seq_id":"seq_1",
+            "cid":"gen",
+            "tool_calls":[{"name":"search","args":"{\"q\":\"hello\"}"}]
+        }"#;
+
+        let event: MSEvent = serde_json::from_str(json).unwrap();
+        let MSEvent::SeqToolCall { tool_calls, .. } = event else {
+            panic!("expected seq_tool_call event");
+        };
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].id, None);
+        assert_eq!(tool_calls[0].name, "search");
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional identifier support for tool calls and tool results; responses now include identifiers when present while remaining compatible with legacy payloads.

* **Chores**
  * Version bumped to 0.4.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mixlayer/modelsocket-rs/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->