### PR TITLE
Add match for tool call streaming events

### DIFF
--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -94,6 +94,11 @@ impl Seq {
             MSEvent::SeqToolCall {
                 cid, tool_calls, ..
             } => self.on_tool_call(cid, tool_calls).await,
+            MSEvent::SeqToolCallStart { .. }
+            | MSEvent::SeqToolCallArgsChunk { .. }
+            | MSEvent::SeqToolCallEnd { .. }
+            | MSEvent::SeqToolCallAborted { .. }
+            | MSEvent::SeqState { .. } => {}
             _ => {
                 warn!("unhandled event in seq: {:?}", event);
             }


### PR DESCRIPTION
Silences `unhandled event` warnings. The MS client does not need these events as it receives a `SeqToolCall` from the server which is the terminal event to process the complete tool call. The events are largely for consumers that might be interested in them, and they can grab them from the event sink.

`SeqState` is similar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool-call lifecycle and state events no longer produce unnecessary warnings during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->