### PR TITLE
Add commands for embedding generation

### DIFF
--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,0 +1,66 @@
+use anyhow::{Context, Result};
+use clap::Parser;
+use modelsocket::{
+    client::{EmbedOpts, ModelSocket},
+    EmbeddingInput, EmbeddingInputType,
+};
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[clap(short, long, default_value = "wss://models.mixlayer.ai/ws")]
+    url: String,
+    #[clap(short, long, env = "MODELSOCKET_API_KEY")]
+    api_key: String,
+    #[clap(short, long, env = "MODELSOCKET_EMBED_MODEL")]
+    model: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    let socket = ModelSocket::connect(&args.url, Some(&args.api_key))
+        .await
+        .context("websocket connection failed")?;
+
+    let seq = socket
+        .open(&args.model, None)
+        .await
+        .context("seq open failed")?;
+
+    let inputs = vec![
+        "Rust is a systems programming language focused on safety and performance.",
+        "Memory-safe systems programming is a core strength of Rust.",
+        "Fresh basil and tomatoes make a simple pasta sauce.",
+    ];
+
+    let opts = EmbedOpts {
+        input_type: Some(EmbeddingInputType::SemanticSimilarity),
+        normalize: Some(true),
+        ..Default::default()
+    };
+
+    let result = seq
+        .embed(
+            inputs
+                .iter()
+                .map(|input| EmbeddingInput::Text((*input).to_string()))
+                .collect(),
+            Some(opts),
+        )
+        .await
+        .context("embed failed")?;
+
+    for (idx, embedding) in result.embeddings.iter().enumerate() {
+        println!(
+            "{}: dimensions={}, input_tokens={}",
+            idx,
+            embedding.len(),
+            result.input_tokens[idx]
+        );
+    }
+
+    println!("prompt_tokens={}", result.prompt_tokens);
+
+    Ok(())
+}

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use modelsocket::{
     client::{EmbedOpts, ModelSocket},
-    EmbeddingInput, EmbeddingInputType,
+    EmbeddingInput,
 };
 
 #[derive(Parser, Debug)]
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     ];
 
     let opts = EmbedOpts {
-        input_type: Some(EmbeddingInputType::SemanticSimilarity),
+        input_type: Some("semantic_similarity".to_string()),
         normalize: Some(true),
         ..Default::default()
     };

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use futures::{Sink, Stream};
 use futures_util::{SinkExt, StreamExt};
-pub use seq::{GenChunk, GenStream, Seq};
+pub use seq::{EmbeddingResult, GenChunk, GenStream, Seq};
 use std::{
     collections::{HashMap, HashSet},
     pin::Pin,
@@ -153,7 +153,16 @@ impl ModelSocketEventHandler {
         debug!("<- {:?}", event);
         match &event {
             MSEvent::SeqOpened { seq_id, cid } => self.on_seq_opened(seq_id, cid).await,
-            MSEvent::Error { cid, message, .. } => self.on_error(cid, message).await,
+            MSEvent::Error {
+                cid,
+                seq_id,
+                message,
+            } => {
+                self.on_error(cid, message).await;
+                if seq_id.is_some() {
+                    self.forward_to_seq(&event).await;
+                }
+            }
             MSEvent::SeqClosed { seq_id, .. } => {
                 // delegate to seq first to allow it to clean up
                 self.forward_to_seq(&event).await;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use futures::{Sink, Stream};
 use futures_util::{SinkExt, StreamExt};
-pub use seq::{EmbeddingResult, GenChunk, GenStream, Seq};
+pub use seq::{EmbedOpts, EmbeddingResult, GenChunk, GenStream, Seq};
 use std::{
     collections::{HashMap, HashSet},
     pin::Pin,

--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -1,7 +1,7 @@
 use crate::{
     protocol::{
-        EmbeddingInput, EmbeddingInputType, MSEvent, MSRequest, SeqAppendReq, SeqCloseReq,
-        SeqCommand, SeqEmbedReq, SeqForkReq, SeqGenReq,
+        EmbeddingInput, MSEvent, MSRequest, SeqAppendReq, SeqCloseReq, SeqCommand, SeqEmbedReq,
+        SeqForkReq, SeqGenReq,
     },
     tools::Toolbox,
     SeqToolCall, SeqToolReturnReq,
@@ -461,7 +461,6 @@ impl Seq {
                 data: SeqCommand::Embed(SeqEmbedReq {
                     inputs,
                     input_type: opts.input_type,
-                    instruction: opts.instruction,
                     dimensions: opts.dimensions,
                     normalize: opts.normalize,
                     truncate: opts.truncate,
@@ -515,8 +514,7 @@ impl Seq {
 
 #[derive(Debug, Default, Clone)]
 pub struct EmbedOpts {
-    pub input_type: Option<EmbeddingInputType>,
-    pub instruction: Option<String>,
+    pub input_type: Option<String>,
     pub dimensions: Option<u32>,
     pub normalize: Option<bool>,
     pub truncate: Option<bool>,

--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -1,5 +1,8 @@
 use crate::{
-    protocol::{MSEvent, MSRequest, SeqAppendReq, SeqCloseReq, SeqCommand, SeqForkReq, SeqGenReq},
+    protocol::{
+        EmbeddingInput, MSEvent, MSRequest, SeqAppendReq, SeqCloseReq, SeqCommand, SeqEmbedReq,
+        SeqForkReq, SeqGenReq,
+    },
     tools::Toolbox,
     SeqToolCall, SeqToolReturnReq,
 };
@@ -34,6 +37,9 @@ pub struct Seq {
     /// open gen streams waiting for a response and their return channels
     gen_streams: Arc<Mutex<HashMap<String, mpsc::Sender<Result<GenChunk, ModelSocketError>>>>>,
 
+    /// open embedding commands waiting for a complete batch response
+    embed_cmds: Arc<Mutex<HashMap<String, EmbedCommandState>>>,
+
     /// tools active on this seq
     toolbox: Arc<Option<Mutex<Box<dyn Toolbox>>>>,
 
@@ -55,6 +61,7 @@ impl Seq {
             socket,
             cmds: Arc::new(Mutex::new(HashMap::new())),
             gen_streams: Arc::new(Mutex::new(HashMap::new())),
+            embed_cmds: Arc::new(Mutex::new(HashMap::new())),
             event_tx,
             toolbox,
         }
@@ -75,6 +82,19 @@ impl Seq {
         match event {
             MSEvent::SeqAppendFinish { cid, .. } => self.on_append_finished(cid).await,
             MSEvent::SeqGenFinish { cid, .. } => self.on_gen_finished(cid).await,
+            MSEvent::SeqEmbedding {
+                cid,
+                index,
+                embedding,
+                input_tokens,
+                ..
+            } => {
+                self.on_embedding(cid, *index, embedding.clone(), *input_tokens)
+                    .await
+            }
+            MSEvent::SeqEmbedFinish {
+                cid, prompt_tokens, ..
+            } => self.on_embed_finished(cid, *prompt_tokens).await,
             MSEvent::SeqForkFinish {
                 cid, child_seq_id, ..
             } => self.on_fork_finished(cid, child_seq_id).await,
@@ -99,6 +119,11 @@ impl Seq {
             | MSEvent::SeqToolCallEnd { .. }
             | MSEvent::SeqToolCallAborted { .. }
             | MSEvent::SeqState { .. } => {}
+            MSEvent::Error { cid, message, .. } => {
+                if let Some(cid) = cid {
+                    self.on_command_error(cid, message).await;
+                }
+            }
             _ => {
                 warn!("unhandled event in seq: {:?}", event);
             }
@@ -142,9 +167,84 @@ impl Seq {
         }
     }
 
+    async fn on_embedding(
+        &mut self,
+        cid: &str,
+        index: u32,
+        embedding: Vec<f32>,
+        input_tokens: u32,
+    ) {
+        let mut embed_cmds = self.embed_cmds.lock().await;
+        let Some(state) = embed_cmds.get_mut(cid) else {
+            warn!("received embedding for unknown cid: {}", cid);
+            return;
+        };
+
+        let index = index as usize;
+        if index >= state.embeddings.len() {
+            warn!(
+                cid,
+                index,
+                len = state.embeddings.len(),
+                "received embedding index out of bounds"
+            );
+            return;
+        }
+
+        state.embeddings[index] = Some(embedding);
+        state.input_tokens[index] = input_tokens;
+    }
+
+    async fn on_embed_finished(&mut self, cid: &str, prompt_tokens: u32) {
+        let Some(state) = self.embed_cmds.lock().await.remove(cid) else {
+            warn!("received embed finish for unknown cid: {}", cid);
+            return;
+        };
+
+        let mut embeddings = Vec::with_capacity(state.embeddings.len());
+        for (idx, embedding) in state.embeddings.into_iter().enumerate() {
+            let Some(embedding) = embedding else {
+                let _ = state
+                    .sender
+                    .send(Err(ModelSocketError::Protocol(format!(
+                        "missing embedding result for index {}",
+                        idx
+                    ))))
+                    .await;
+                return;
+            };
+            embeddings.push(embedding);
+        }
+
+        let _ = state
+            .sender
+            .send(Ok(EmbeddingResult {
+                embeddings,
+                input_tokens: state.input_tokens,
+                prompt_tokens,
+            }))
+            .await;
+    }
+
     async fn on_append_finished(&mut self, cid: &str) {
         if let Some(sender) = self.cmds.lock().await.remove(cid) {
             let _ = sender.send(Ok(serde_json::Value::Null)).await;
+        }
+    }
+
+    async fn on_command_error(&mut self, cid: &str, message: &str) {
+        let err = || ModelSocketError::Command(message.to_string());
+
+        if let Some(sender) = self.cmds.lock().await.remove(cid) {
+            let _ = sender.send(Err(err())).await;
+        }
+
+        if let Some(sender) = self.gen_streams.lock().await.remove(cid) {
+            let _ = sender.send(Err(err())).await;
+        }
+
+        if let Some(state) = self.embed_cmds.lock().await.remove(cid) {
+            let _ = state.sender.send(Err(err())).await;
         }
     }
 
@@ -310,6 +410,41 @@ impl Seq {
         Ok(child_seq)
     }
 
+    pub async fn embed(
+        &self,
+        inputs: Vec<EmbeddingInput>,
+        dimensions: Option<u32>,
+        normalize: Option<bool>,
+    ) -> Result<EmbeddingResult, ModelSocketError> {
+        let cid = Uuid::new_v4().to_string();
+        let (tx, mut rx) = mpsc::channel(1);
+
+        self.embed_cmds.lock().await.insert(
+            cid.clone(),
+            EmbedCommandState {
+                embeddings: vec![None; inputs.len()],
+                input_tokens: vec![0; inputs.len()],
+                sender: tx,
+            },
+        );
+
+        self.socket
+            .send_request(MSRequest::SeqCommand {
+                cid,
+                seq_id: self.seq_id.clone(),
+                data: SeqCommand::Embed(SeqEmbedReq {
+                    inputs,
+                    dimensions,
+                    normalize,
+                }),
+            })
+            .await?;
+
+        rx.recv().await.ok_or_else(|| {
+            ModelSocketError::Command("failed to receive embedding response".into())
+        })?
+    }
+
     /// sends an error to any outstanding commands or streams on this seq
     async fn fail_cmds_with_close_error(&self) {
         let mut cmds = self.cmds.lock().await;
@@ -321,6 +456,11 @@ impl Seq {
         let mut gen_streams = self.gen_streams.lock().await;
         for (_cid, tx) in gen_streams.drain() {
             let _ = tx.send(Err(ModelSocketError::SeqClosed)).await;
+        }
+
+        let mut embed_cmds = self.embed_cmds.lock().await;
+        for (_cid, state) in embed_cmds.drain() {
+            let _ = state.sender.send(Err(ModelSocketError::SeqClosed)).await;
         }
     }
 
@@ -390,4 +530,17 @@ pub struct GenChunk {
     pub text: String,
     pub hidden: bool,
     pub tokens: Option<Vec<u32>>,
+}
+
+struct EmbedCommandState {
+    embeddings: Vec<Option<Vec<f32>>>,
+    input_tokens: Vec<u32>,
+    sender: mpsc::Sender<Result<EmbeddingResult, ModelSocketError>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbeddingResult {
+    pub embeddings: Vec<Vec<f32>>,
+    pub input_tokens: Vec<u32>,
+    pub prompt_tokens: u32,
 }

--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -122,6 +122,8 @@ impl Seq {
             MSEvent::Error { cid, message, .. } => {
                 if let Some(cid) = cid {
                     self.on_command_error(cid, message).await;
+                } else {
+                    self.on_seq_error(message).await;
                 }
             }
             _ => {
@@ -235,15 +237,39 @@ impl Seq {
     async fn on_command_error(&mut self, cid: &str, message: &str) {
         let err = || ModelSocketError::Command(message.to_string());
 
-        if let Some(sender) = self.cmds.lock().await.remove(cid) {
+        let cmd = self.cmds.lock().await.remove(cid);
+        let gen_stream = self.gen_streams.lock().await.remove(cid);
+        let embed_cmd = self.embed_cmds.lock().await.remove(cid);
+
+        if let Some(sender) = cmd {
             let _ = sender.send(Err(err())).await;
         }
 
-        if let Some(sender) = self.gen_streams.lock().await.remove(cid) {
+        if let Some(sender) = gen_stream {
             let _ = sender.send(Err(err())).await;
         }
 
-        if let Some(state) = self.embed_cmds.lock().await.remove(cid) {
+        if let Some(state) = embed_cmd {
+            let _ = state.sender.send(Err(err())).await;
+        }
+    }
+
+    async fn on_seq_error(&mut self, message: &str) {
+        let err = || ModelSocketError::Command(message.to_string());
+
+        let cmds = std::mem::take(&mut *self.cmds.lock().await);
+        let gen_streams = std::mem::take(&mut *self.gen_streams.lock().await);
+        let embed_cmds = std::mem::take(&mut *self.embed_cmds.lock().await);
+
+        for (_cid, tx) in cmds {
+            let _ = tx.send(Err(err())).await;
+        }
+
+        for (_cid, tx) in gen_streams {
+            let _ = tx.send(Err(err())).await;
+        }
+
+        for (_cid, state) in embed_cmds {
             let _ = state.sender.send(Err(err())).await;
         }
     }
@@ -555,4 +581,127 @@ pub struct EmbeddingResult {
     pub embeddings: Vec<Vec<f32>>,
     pub input_tokens: Vec<u32>,
     pub prompt_tokens: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::Sink;
+    use std::task::{Context, Poll};
+    use tokio::time::{timeout, Duration};
+
+    struct RequestSink;
+
+    impl Sink<MSRequest> for RequestSink {
+        type Error = ModelSocketError;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, _item: MSRequest) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn test_socket() -> ModelSocket {
+        let ws_sink: Pin<Box<dyn Sink<MSRequest, Error = ModelSocketError> + Send>> =
+            Box::pin(RequestSink);
+
+        ModelSocket {
+            ws_sink: Arc::new(Mutex::new(ws_sink)),
+            opening_seqs: Default::default(),
+            seqs: Default::default(),
+            closed_seqs: Default::default(),
+        }
+    }
+
+    fn assert_command_error<T>(result: Result<T, ModelSocketError>, message: &str) {
+        match result {
+            Err(ModelSocketError::Command(error)) => assert_eq!(error, message),
+            Err(error) => panic!("expected command error, got {error:?}"),
+            Ok(_) => panic!("expected command error, got ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn seq_level_error_fails_all_pending_commands_and_streams() {
+        let mut seq = Seq::new(
+            "seq-1".to_string(),
+            "model".to_string(),
+            test_socket(),
+            Arc::new(None),
+            None,
+        );
+
+        let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+        seq.cmds.lock().await.insert("cmd-1".to_string(), cmd_tx);
+
+        let (gen_tx, mut gen_rx) = mpsc::channel(1);
+        seq.gen_streams
+            .lock()
+            .await
+            .insert("gen-1".to_string(), gen_tx);
+
+        let (embed_tx, mut embed_rx) = mpsc::channel(1);
+        seq.embed_cmds.lock().await.insert(
+            "embed-1".to_string(),
+            EmbedCommandState {
+                embeddings: vec![None],
+                input_tokens: vec![0],
+                sender: embed_tx,
+            },
+        );
+
+        let message = "seq failed";
+        seq.on_event(&MSEvent::Error {
+            cid: None,
+            seq_id: Some("seq-1".to_string()),
+            message: message.to_string(),
+        })
+        .await;
+
+        assert_command_error(
+            timeout(Duration::from_millis(100), cmd_rx.recv())
+                .await
+                .expect("cmd error should be sent")
+                .expect("cmd channel should remain open"),
+            message,
+        );
+        assert_command_error(
+            timeout(Duration::from_millis(100), gen_rx.recv())
+                .await
+                .expect("gen error should be sent")
+                .expect("gen channel should remain open"),
+            message,
+        );
+        assert_command_error(
+            timeout(Duration::from_millis(100), embed_rx.recv())
+                .await
+                .expect("embed error should be sent")
+                .expect("embed channel should remain open"),
+            message,
+        );
+
+        assert!(seq.cmds.lock().await.is_empty());
+        assert!(seq.gen_streams.lock().await.is_empty());
+        assert!(seq.embed_cmds.lock().await.is_empty());
+    }
 }

--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -1,7 +1,7 @@
 use crate::{
     protocol::{
-        EmbeddingInput, MSEvent, MSRequest, SeqAppendReq, SeqCloseReq, SeqCommand, SeqEmbedReq,
-        SeqForkReq, SeqGenReq,
+        EmbeddingInput, EmbeddingInputType, MSEvent, MSRequest, SeqAppendReq, SeqCloseReq,
+        SeqCommand, SeqEmbedReq, SeqForkReq, SeqGenReq,
     },
     tools::Toolbox,
     SeqToolCall, SeqToolReturnReq,
@@ -413,11 +413,11 @@ impl Seq {
     pub async fn embed(
         &self,
         inputs: Vec<EmbeddingInput>,
-        dimensions: Option<u32>,
-        normalize: Option<bool>,
+        opts: Option<EmbedOpts>,
     ) -> Result<EmbeddingResult, ModelSocketError> {
         let cid = Uuid::new_v4().to_string();
         let (tx, mut rx) = mpsc::channel(1);
+        let opts = opts.unwrap_or_default();
 
         self.embed_cmds.lock().await.insert(
             cid.clone(),
@@ -434,8 +434,11 @@ impl Seq {
                 seq_id: self.seq_id.clone(),
                 data: SeqCommand::Embed(SeqEmbedReq {
                     inputs,
-                    dimensions,
-                    normalize,
+                    input_type: opts.input_type,
+                    instruction: opts.instruction,
+                    dimensions: opts.dimensions,
+                    normalize: opts.normalize,
+                    truncate: opts.truncate,
                 }),
             })
             .await?;
@@ -482,6 +485,15 @@ impl Seq {
 
         Ok(())
     }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct EmbedOpts {
+    pub input_type: Option<EmbeddingInputType>,
+    pub instruction: Option<String>,
+    pub dimensions: Option<u32>,
+    pub normalize: Option<bool>,
+    pub truncate: Option<bool>,
 }
 
 pub struct GenStream {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -28,6 +28,7 @@ pub enum SeqCommand {
     Close(SeqCloseReq),
     Append(SeqAppendReq),
     Gen(SeqGenReq),
+    Embed(SeqEmbedReq),
     ToolReturn(SeqToolReturnReq),
     Fork(SeqForkReq),
 }
@@ -52,6 +53,18 @@ pub enum MSEvent {
     SeqGenFinish {
         seq_id: String,
         cid: String,
+    },
+    SeqEmbedding {
+        seq_id: String,
+        cid: String,
+        index: u32,
+        embedding: Vec<f32>,
+        input_tokens: u32,
+    },
+    SeqEmbedFinish {
+        seq_id: String,
+        cid: String,
+        prompt_tokens: u32,
     },
     SeqForkFinish {
         seq_id: String,
@@ -128,6 +141,8 @@ impl MSEvent {
             MSEvent::SeqOpened { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqAppendFinish { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqGenFinish { cid, .. } => Some(cid.as_str()),
+            MSEvent::SeqEmbedding { cid, .. } => Some(cid.as_str()),
+            MSEvent::SeqEmbedFinish { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqForkFinish { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqText { cid, .. } => Some(cid.as_str()),
             MSEvent::SeqToolCall { cid, .. } => Some(cid.as_str()),
@@ -146,6 +161,8 @@ impl MSEvent {
             MSEvent::SeqOpened { .. } => "seq_opened",
             MSEvent::SeqAppendFinish { .. } => "seq_append_finish",
             MSEvent::SeqGenFinish { .. } => "seq_gen_finish",
+            MSEvent::SeqEmbedding { .. } => "seq_embedding",
+            MSEvent::SeqEmbedFinish { .. } => "seq_embed_finish",
             MSEvent::SeqForkFinish { .. } => "seq_fork_finish",
             MSEvent::SeqText { .. } => "seq_text",
             MSEvent::SeqToolCall { .. } => "seq_tool_call",
@@ -164,6 +181,8 @@ impl MSEvent {
             MSEvent::SeqOpened { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqAppendFinish { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqGenFinish { seq_id, .. } => Some(seq_id.as_str()),
+            MSEvent::SeqEmbedding { seq_id, .. } => Some(seq_id.as_str()),
+            MSEvent::SeqEmbedFinish { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqForkFinish { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqText { seq_id, .. } => Some(seq_id.as_str()),
             MSEvent::SeqToolCall { seq_id, .. } => Some(seq_id.as_str()),
@@ -275,6 +294,22 @@ pub struct SeqGenReq {
     pub frequency_penalty: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub presence_penalty: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingInput {
+    Text(String),
+    Tokens(Vec<u32>),
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct SeqEmbedReq {
+    pub inputs: Vec<EmbeddingInput>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dimensions: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub normalize: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -303,27 +303,11 @@ pub enum EmbeddingInput {
     Tokens(Vec<u32>),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum EmbeddingInputType {
-    SearchQuery,
-    SearchDocument,
-    Classification,
-    Clustering,
-    SemanticSimilarity,
-    CodeSearchQuery,
-    CodeSearchDocument,
-    BitextMining,
-    Image,
-}
-
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct SeqEmbedReq {
     pub inputs: Vec<EmbeddingInput>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub input_type: Option<EmbeddingInputType>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub instruction: Option<String>,
+    pub input_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dimensions: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -103,7 +103,7 @@ pub enum MSEvent {
         seq_id: String,
         cid: String,
         index: u32,
-        args: String
+        args: String,
     },
     SeqToolCallAborted {
         seq_id: String,
@@ -303,13 +303,33 @@ pub enum EmbeddingInput {
     Tokens(Vec<u32>),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingInputType {
+    SearchQuery,
+    SearchDocument,
+    Classification,
+    Clustering,
+    SemanticSimilarity,
+    CodeSearchQuery,
+    CodeSearchDocument,
+    BitextMining,
+    Image,
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct SeqEmbedReq {
     pub inputs: Vec<EmbeddingInput>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_type: Option<EmbeddingInputType>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instruction: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dimensions: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub normalize: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncate: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This PR adds embedding generation support to ModelSocket

The protocol takes the following shape:

```
client -->
  seq_command:
    data:
      command: embed
      inputs:
        - generate embeddings for this
        - and also generate embeddings for this
      dimensions: 768
      normalize: true
      ...

<-- server, streamed back to you as they're generated
  seq_embedding:
    index: 0
    embedding: []
    input_tokens: 2

  seq_embedding:
    index: 1
    embedding: []
    input_tokens: 2

  seq_embed_finish:
    prompt_tokens: 4
```

The MS Rust client sees:

```
EmbeddingResult {
  embeddings:
    - []
    - []
  input_tokens: [2, 2]
  prompt_tokens: 4 # may be different than sum(input_tokens) if a prompt/instruction was supplied
}
```

Given we're likely to support different models which will have different input intent, the `SeqEmbedReq` supports option optional fields which may/may not be used depending on the modal:

* `input_type` - see `EmbeddingInputType` for a somewhat normalised list
* `instruction` - "Given a web search query, retrieve relevant passages that answer the query", etc
* `truncate` - should the modal truncate any input to the context limit?
* `normalize` - should embedding values be normalized server side or not?
* `dimensions` - # of dimensions to return 

There's also some error routing changes in this branch: while seq-scoped errors are forwarded to the owning `Seq`, using the sequence ID


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Seq::embed` for end-to-end batched embeddings returning `EmbeddingResult` (embeddings, `input_tokens`, `prompt_tokens`) and configurable via `EmbedOpts`.
  * Extended the model socket protocol with embedding request/events to stream per-index embeddings and a finish event.
  * Added a new embedding example CLI.

* **Bug Fixes**
  * Improved error routing and ensured pending embed batches are completed with appropriate errors on command failures or seq closure.

* **Documentation / Tests**
  * Re-exported embedding-related types at the client level and added a unit test covering seq-level error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->