### PR TITLE
Add support for appending media (vision support)

### DIFF
--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -1,7 +1,7 @@
 use crate::{
     protocol::{
-        EmbeddingInput, MSEvent, MSRequest, SeqAppendReq, SeqCloseReq, SeqCommand, SeqEmbedReq,
-        SeqForkReq, SeqGenReq,
+        EmbeddingInput, MSEvent, MSRequest, SeqAppendMedia, SeqAppendReq, SeqCloseReq, SeqCommand,
+        SeqEmbedReq, SeqForkReq, SeqGenReq,
     },
     tools::Toolbox,
     SeqToolCall, SeqToolReturnReq,
@@ -364,6 +364,34 @@ impl Seq {
                 seq_id: self.seq_id.clone(),
                 data: SeqCommand::Append(SeqAppendReq {
                     text: text.as_ref().to_string(),
+                    role: opts.role,
+                    ..Default::default()
+                }),
+            })
+            .await?;
+
+        rx.recv()
+            .await
+            .ok_or_else(|| ModelSocketError::Command("failed to receive response".into()))??;
+
+        Ok(())
+    }
+
+    pub async fn append_media(
+        &self,
+        media: SeqAppendMedia,
+        opts: AppendOpts,
+    ) -> Result<(), ModelSocketError> {
+        let cid = Uuid::new_v4().to_string();
+        let (tx, mut rx) = mpsc::channel(1);
+        self.cmds.lock().await.insert(cid.clone(), tx);
+
+        self.socket
+            .send_request(MSRequest::SeqCommand {
+                cid: cid.clone(),
+                seq_id: self.seq_id.clone(),
+                data: SeqCommand::Append(SeqAppendReq {
+                    media: Some(media),
                     role: opts.role,
                     ..Default::default()
                 }),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -216,15 +216,32 @@ pub struct SeqOpenReq {
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SeqAppendReq {
+    #[serde(default)]
     pub text: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tokens: Option<Vec<u32>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub media: Option<SeqAppendMedia>,
     #[serde(default)]
     pub hidden: bool,
     #[serde(default)]
     pub echo: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub role: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeqAppendMedia {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 /// Sequence capabilities
@@ -346,7 +363,10 @@ pub struct SeqToolCall {
 
 #[cfg(test)]
 mod tests {
-    use super::{MSEvent, SeqToolCall, SeqToolReturnReq, ToolResult};
+    use super::{
+        MSEvent, SeqAppendMedia, SeqAppendReq, SeqCommand, SeqToolCall, SeqToolReturnReq,
+        ToolResult,
+    };
 
     #[test]
     fn seq_tool_call_deserializes_without_id() {
@@ -385,6 +405,74 @@ mod tests {
 
         let json = serde_json::to_string(&call).unwrap();
         assert!(!json.contains(r#""id""#));
+    }
+
+    #[test]
+    fn append_request_deserializes_legacy_text_payload() {
+        let json = r#"{"text":"hello","hidden":false,"echo":false,"role":"user"}"#;
+        let req: SeqAppendReq = serde_json::from_str(json).unwrap();
+
+        assert_eq!(req.text, "hello");
+        assert_eq!(req.role.as_deref(), Some("user"));
+        assert!(req.media.is_none());
+    }
+
+    #[test]
+    fn append_command_round_trips_with_media_uri() {
+        let cmd = SeqCommand::Append(SeqAppendReq {
+            text: String::new(),
+            media: Some(SeqAppendMedia {
+                uri: Some("https://example.com/cat.png".to_string()),
+                blob: None,
+                hash: Some("b3abc".to_string()),
+                mime_type: Some("image/png".to_string()),
+                detail: Some("auto".to_string()),
+            }),
+            role: Some("user".to_string()),
+            ..Default::default()
+        });
+
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains(r#""command":"append""#));
+        assert!(json.contains(r#""uri":"https://example.com/cat.png""#));
+
+        let parsed: SeqCommand = serde_json::from_str(&json).unwrap();
+        let SeqCommand::Append(parsed) = parsed else {
+            panic!("expected append command");
+        };
+        let media = parsed.media.expect("media should roundtrip");
+
+        assert_eq!(media.uri.as_deref(), Some("https://example.com/cat.png"));
+        assert_eq!(media.mime_type.as_deref(), Some("image/png"));
+        assert_eq!(media.detail.as_deref(), Some("auto"));
+    }
+
+    #[test]
+    fn append_command_round_trips_with_media_blob() {
+        let cmd = SeqCommand::Append(SeqAppendReq {
+            text: String::new(),
+            media: Some(SeqAppendMedia {
+                uri: None,
+                blob: Some("aW1hZ2U=".to_string()),
+                hash: Some("b3abc".to_string()),
+                mime_type: Some("image/png".to_string()),
+                detail: Some("low".to_string()),
+            }),
+            role: Some("user".to_string()),
+            ..Default::default()
+        });
+
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains(r#""blob":"aW1hZ2U=""#));
+
+        let parsed: SeqCommand = serde_json::from_str(&json).unwrap();
+        let SeqCommand::Append(parsed) = parsed else {
+            panic!("expected append command");
+        };
+        let media = parsed.media.expect("media should roundtrip");
+
+        assert_eq!(media.blob.as_deref(), Some("aW1hZ2U="));
+        assert_eq!(media.detail.as_deref(), Some("low"));
     }
 
     #[test]


### PR DESCRIPTION
Media is carried with a `append`:

```
seq_command:
  data: 
    command: append
    media:
      uri: https://example.com/image.png
      blob: base64 encoded bytes if you have that instead
      mime_type: mime type if you have it
      hash: optional hash we'll verify if you pass it
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching media when creating a sequence entry, including media details like URI or blob data.
  * Sequence text submissions now handle missing text more flexibly.

* **Bug Fixes**
  * Improved compatibility with older sequence requests that don’t include media.
  * Ensured media attachments are sent and received correctly during sequence updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->