### PR TITLE
Add content part support in prep for multi-modal embedding models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .vscode
 .venv
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "modelsocket"
-version = "0.4.9"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.4.9"
+version = "0.5.1"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -231,7 +231,7 @@ pub struct SeqAppendReq {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SeqAppendMedia {
+pub struct MediaInput {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub uri: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -243,6 +243,9 @@ pub struct SeqAppendMedia {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
 }
+
+pub type SeqAppendMedia = MediaInput;
+pub type EmbedMediaInput = MediaInput;
 
 /// Sequence capabilities
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -318,6 +321,14 @@ pub struct SeqGenReq {
 pub enum EmbeddingInput {
     Text(String),
     Tokens(Vec<u32>),
+    Content(Vec<EmbeddingContentPart>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddingContentPart {
+    Text(String),
+    Media(EmbedMediaInput),
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
@@ -364,9 +375,19 @@ pub struct SeqToolCall {
 #[cfg(test)]
 mod tests {
     use super::{
-        MSEvent, SeqAppendMedia, SeqAppendReq, SeqCommand, SeqToolCall, SeqToolReturnReq,
-        ToolResult,
+        EmbeddingContentPart, EmbeddingInput, MSEvent, SeqAppendMedia, SeqAppendReq, SeqCommand,
+        SeqEmbedReq, SeqToolCall, SeqToolReturnReq, ToolResult,
     };
+    use serde_json::{json, Value};
+
+    fn round_trip_embed(value: Value) -> SeqEmbedReq {
+        let cmd: SeqCommand = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&cmd).unwrap(), value);
+        let SeqCommand::Embed(req) = cmd else {
+            panic!("expected embed command");
+        };
+        req
+    }
 
     #[test]
     fn seq_tool_call_deserializes_without_id() {
@@ -472,6 +493,80 @@ mod tests {
         let media = parsed.media.expect("media should roundtrip");
 
         assert_eq!(media.blob.as_deref(), Some("aW1hZ2U="));
+        assert_eq!(media.detail.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn embed_command_supports_simple_inputs() {
+        let req = round_trip_embed(json!({
+            "command": "embed",
+            "inputs": [
+                { "text": "hello" },
+                { "tokens": [1, 2, 3] }
+            ]
+        }));
+        assert!(matches!(
+            &req.inputs[..],
+            [EmbeddingInput::Text(text), EmbeddingInput::Tokens(tokens)]
+                if text == "hello" && tokens == &[1, 2, 3]
+        ));
+    }
+
+    #[test]
+    fn embed_command_supports_content_with_media_uri() {
+        let req = round_trip_embed(json!({
+            "command": "embed",
+            "inputs": [{
+                "content": [
+                    { "text": "A bicycle" },
+                    { "media": {
+                        "uri": "https://example.com/bicycle.png",
+                        "mime_type": "image/png",
+                        "detail": "high"
+                    }}
+                ]
+            }]
+        }));
+        let EmbeddingInput::Content(parts) = &req.inputs[0] else {
+            panic!("expected content input");
+        };
+        let [EmbeddingContentPart::Text(text), EmbeddingContentPart::Media(media)] = &parts[..]
+        else {
+            panic!("expected ordered text and media parts");
+        };
+        assert_eq!(text, "A bicycle");
+        assert_eq!(
+            media.uri.as_deref(),
+            Some("https://example.com/bicycle.png")
+        );
+        assert_eq!(media.mime_type.as_deref(), Some("image/png"));
+        assert_eq!(media.detail.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn embed_command_supports_content_with_media_blob() {
+        let req = round_trip_embed(json!({
+            "command": "embed",
+            "inputs": [{
+                "content": [{
+                    "media": {
+                        "blob": "aW1hZ2U=",
+                        "hash": "b3abc",
+                        "mime_type": "image/png",
+                        "detail": "low"
+                    }
+                }]
+            }]
+        }));
+        let EmbeddingInput::Content(parts) = &req.inputs[0] else {
+            panic!("expected content input");
+        };
+        let EmbeddingContentPart::Media(media) = &parts[0] else {
+            panic!("expected media part");
+        };
+        assert_eq!(media.blob.as_deref(), Some("aW1hZ2U="));
+        assert_eq!(media.hash.as_deref(), Some("b3abc"));
+        assert_eq!(media.mime_type.as_deref(), Some("image/png"));
         assert_eq!(media.detail.as_deref(), Some("low"));
     }
 


### PR DESCRIPTION
The shape of this matches media for `SeqAppend` - from the modelsocket perspective it's something like:

```json
{
  "request": "seq_command",
  "cid": "embed-1",
  "seq_id": "seq-123",
  "data": {
    "command": "embed",
    "inputs": [
      {
        "content": [
          {
            "text": "Find products similar to this bicycle"
          },
          {
            "media": {
              "uri": "https://example.com/bicycle.png",
              "mime_type": "image/png",
              "detail": "high"
            }
          }
        ]
      }
    ],
    "input_type": "image",
    "dimensions": 1024,
    "normalize": true,
    "truncate": false
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedding content that includes text and media.
  * Media inputs can now reference a URI or embedded content, with optional metadata such as MIME type, detail, and hash.
  * Added reliable serialization and deserialization for embedding requests.

* **Bug Fixes**
  * Improved consistency in handling media inputs across supported operations.

* **Chores**
  * Updated the release version to 0.5.1.
  * Added macOS system files to the ignored files list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->