### PR TITLE
Add error codes + details to SeqError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "modelsocket"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,7 +3,7 @@ pub mod tools;
 pub mod transport;
 
 use crate::{
-    protocol::{MSEvent, MSRequest, SeqGenReq, SeqOpenReq},
+    protocol::{MSEvent, MSRequest, RateLimitErrorDetails, SeqGenReq, SeqOpenReq},
     tools::Toolbox,
 };
 use futures::{Sink, Stream};
@@ -48,6 +48,13 @@ pub enum ModelSocketError {
 
     #[error("command error: {0}")]
     Command(String),
+
+    #[error("{message}")]
+    RateLimit {
+        message: String,
+        code: String,
+        details: RateLimitErrorDetails,
+    },
 
     #[error("{0}")]
     Other(#[from] anyhow::Error),
@@ -156,8 +163,10 @@ impl ModelSocketEventHandler {
                 cid,
                 seq_id,
                 message,
+                code,
+                rate_limit,
             } => {
-                self.on_error(cid, message).await;
+                self.on_error(cid, message, code, rate_limit).await;
                 if seq_id.is_some() {
                     self.forward_to_seq(&event).await;
                 }
@@ -202,16 +211,21 @@ impl ModelSocketEventHandler {
         }
     }
 
-    async fn on_error(&self, cid: &Option<String>, message: &str) {
+    async fn on_error(
+        &self,
+        cid: &Option<String>,
+        message: &str,
+        code: &Option<String>,
+        rate_limit: &Option<RateLimitErrorDetails>,
+    ) {
         error!("error: {}", message);
 
         if let Some(cid) = cid {
             if let Some(sender) = self.opening_seqs.lock().await.remove(cid) {
                 let _ = sender
-                    .send(Err(ModelSocketError::Open(format!(
-                        "open error: {}",
-                        message
-                    ))))
+                    .send(Err(remote_error(message, code, rate_limit).unwrap_or_else(
+                        || ModelSocketError::Open(format!("open error: {message}")),
+                    )))
                     .await;
             }
         }
@@ -240,6 +254,18 @@ impl ModelSocketEventHandler {
             error!("unknown opened seq cid {}", cid);
         }
     }
+}
+
+fn remote_error(
+    message: &str,
+    code: &Option<String>,
+    rate_limit: &Option<RateLimitErrorDetails>,
+) -> Option<ModelSocketError> {
+    Some(ModelSocketError::RateLimit {
+        message: message.to_string(),
+        code: code.clone()?,
+        details: rate_limit.clone()?,
+    })
 }
 
 impl ModelSocket {
@@ -495,5 +521,50 @@ mod tests {
         assert!(closed.is_none());
 
         drop(event_tx);
+    }
+
+    #[tokio::test]
+    async fn open_error_preserves_rate_limit_details() {
+        let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let socket = ModelSocket::new(ChannelTransport {
+            requests: request_tx,
+            events: event_rx,
+        })
+        .unwrap();
+        let open = tokio::spawn(async move { socket.open("model", None).await });
+        let MSRequest::SeqOpen { cid, .. } = request_rx.recv().await.unwrap() else {
+            panic!("expected sequence open");
+        };
+        let details = RateLimitErrorDetails {
+            cause: "rate_limited".into(),
+            enforcement_mode: "enforced".into(),
+            rpm_limit: 60,
+            rpm_remaining: 0,
+            tpm_limit: 100_000,
+            tpm_remaining: 0,
+            retry_after_ms: 1_000,
+        };
+        event_tx
+            .send(Ok(MSEvent::Error {
+                cid: Some(cid),
+                seq_id: Some("seq-1".into()),
+                message: "Rate limit exceeded".into(),
+                code: Some("rate_limit_exceeded".into()),
+                rate_limit: Some(details.clone()),
+            }))
+            .unwrap();
+
+        match open.await.unwrap() {
+            Err(ModelSocketError::RateLimit {
+                code,
+                details: actual,
+                ..
+            }) => {
+                assert_eq!(code, "rate_limit_exceeded");
+                assert_eq!(actual, details);
+            }
+            _ => panic!("expected structured rate-limit error"),
+        }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -3,7 +3,7 @@ pub mod tools;
 pub mod transport;
 
 use crate::{
-    protocol::{MSEvent, MSRequest, RateLimitErrorDetails, SeqGenReq, SeqOpenReq},
+    protocol::{MSEvent, MSRequest, SeqGenReq, SeqOpenReq},
     tools::Toolbox,
 };
 use futures::{Sink, Stream};
@@ -50,10 +50,10 @@ pub enum ModelSocketError {
     Command(String),
 
     #[error("{message}")]
-    RateLimit {
+    Remote {
         message: String,
-        code: String,
-        details: RateLimitErrorDetails,
+        code: Option<String>,
+        details: Option<serde_json::Map<String, serde_json::Value>>,
     },
 
     #[error("{0}")]
@@ -164,9 +164,9 @@ impl ModelSocketEventHandler {
                 seq_id,
                 message,
                 code,
-                rate_limit,
+                details,
             } => {
-                self.on_error(cid, message, code, rate_limit).await;
+                self.on_error(cid, message, code, details).await;
                 if seq_id.is_some() {
                     self.forward_to_seq(&event).await;
                 }
@@ -216,17 +216,13 @@ impl ModelSocketEventHandler {
         cid: &Option<String>,
         message: &str,
         code: &Option<String>,
-        rate_limit: &Option<RateLimitErrorDetails>,
+        details: &Option<serde_json::Map<String, serde_json::Value>>,
     ) {
         error!("error: {}", message);
 
         if let Some(cid) = cid {
             if let Some(sender) = self.opening_seqs.lock().await.remove(cid) {
-                let _ = sender
-                    .send(Err(remote_error(message, code, rate_limit).unwrap_or_else(
-                        || ModelSocketError::Open(format!("open error: {message}")),
-                    )))
-                    .await;
+                let _ = sender.send(Err(remote_error(message, code, details))).await;
             }
         }
     }
@@ -259,13 +255,13 @@ impl ModelSocketEventHandler {
 fn remote_error(
     message: &str,
     code: &Option<String>,
-    rate_limit: &Option<RateLimitErrorDetails>,
-) -> Option<ModelSocketError> {
-    Some(ModelSocketError::RateLimit {
+    details: &Option<serde_json::Map<String, serde_json::Value>>,
+) -> ModelSocketError {
+    ModelSocketError::Remote {
         message: message.to_string(),
-        code: code.clone()?,
-        details: rate_limit.clone()?,
-    })
+        code: code.clone(),
+        details: details.clone(),
+    }
 }
 
 impl ModelSocket {
@@ -524,7 +520,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn open_error_preserves_rate_limit_details() {
+    async fn open_error_preserves_remote_details() {
         let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
         let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
         let socket = ModelSocket::new(ChannelTransport {
@@ -536,35 +532,36 @@ mod tests {
         let MSRequest::SeqOpen { cid, .. } = request_rx.recv().await.unwrap() else {
             panic!("expected sequence open");
         };
-        let details = RateLimitErrorDetails {
-            cause: "rate_limited".into(),
-            enforcement_mode: "enforced".into(),
-            rpm_limit: 60,
-            rpm_remaining: 0,
-            tpm_limit: 100_000,
-            tpm_remaining: 0,
-            retry_after_ms: 1_000,
-        };
+        let details = serde_json::json!({
+            "rpm_limit": 60,
+            "rpm_remaining": 0,
+            "tpm_limit": 100_000,
+            "tpm_remaining": 0,
+            "retry_after_ms": 1_000
+        })
+        .as_object()
+        .unwrap()
+        .clone();
         event_tx
             .send(Ok(MSEvent::Error {
                 cid: Some(cid),
                 seq_id: Some("seq-1".into()),
                 message: "Rate limit exceeded".into(),
                 code: Some("rate_limit_exceeded".into()),
-                rate_limit: Some(details.clone()),
+                details: Some(details.clone()),
             }))
             .unwrap();
 
         match open.await.unwrap() {
-            Err(ModelSocketError::RateLimit {
+            Err(ModelSocketError::Remote {
                 code,
                 details: actual,
                 ..
             }) => {
-                assert_eq!(code, "rate_limit_exceeded");
-                assert_eq!(actual, details);
+                assert_eq!(code.as_deref(), Some("rate_limit_exceeded"));
+                assert_eq!(actual, Some(details));
             }
-            _ => panic!("expected structured rate-limit error"),
+            _ => panic!("expected structured remote error"),
         }
     }
 }

--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -119,11 +119,17 @@ impl Seq {
             | MSEvent::SeqToolCallEnd { .. }
             | MSEvent::SeqToolCallAborted { .. }
             | MSEvent::SeqState { .. } => {}
-            MSEvent::Error { cid, message, .. } => {
+            MSEvent::Error {
+                cid,
+                message,
+                code,
+                rate_limit,
+                ..
+            } => {
                 if let Some(cid) = cid {
-                    self.on_command_error(cid, message).await;
+                    self.on_command_error(cid, message, code, rate_limit).await;
                 } else {
-                    self.on_seq_error(message).await;
+                    self.on_seq_error(message, code, rate_limit).await;
                 }
             }
             _ => {
@@ -234,8 +240,17 @@ impl Seq {
         }
     }
 
-    async fn on_command_error(&mut self, cid: &str, message: &str) {
-        let err = || ModelSocketError::Command(message.to_string());
+    async fn on_command_error(
+        &mut self,
+        cid: &str,
+        message: &str,
+        code: &Option<String>,
+        rate_limit: &Option<crate::RateLimitErrorDetails>,
+    ) {
+        let err = || {
+            super::remote_error(message, code, rate_limit)
+                .unwrap_or_else(|| ModelSocketError::Command(message.to_string()))
+        };
 
         let cmd = self.cmds.lock().await.remove(cid);
         let gen_stream = self.gen_streams.lock().await.remove(cid);
@@ -254,8 +269,16 @@ impl Seq {
         }
     }
 
-    async fn on_seq_error(&mut self, message: &str) {
-        let err = || ModelSocketError::Command(message.to_string());
+    async fn on_seq_error(
+        &mut self,
+        message: &str,
+        code: &Option<String>,
+        rate_limit: &Option<crate::RateLimitErrorDetails>,
+    ) {
+        let err = || {
+            super::remote_error(message, code, rate_limit)
+                .unwrap_or_else(|| ModelSocketError::Command(message.to_string()))
+        };
 
         let cmds = std::mem::take(&mut *self.cmds.lock().await);
         let gen_streams = std::mem::take(&mut *self.gen_streams.lock().await);
@@ -701,6 +724,8 @@ mod tests {
             cid: None,
             seq_id: Some("seq-1".to_string()),
             message: message.to_string(),
+            code: None,
+            rate_limit: None,
         })
         .await;
 
@@ -729,5 +754,48 @@ mod tests {
         assert!(seq.cmds.lock().await.is_empty());
         assert!(seq.gen_streams.lock().await.is_empty());
         assert!(seq.embed_cmds.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn command_error_preserves_rate_limit_details() {
+        let mut seq = Seq::new(
+            "seq-1".to_string(),
+            "model".to_string(),
+            test_socket(),
+            Arc::new(None),
+            None,
+        );
+        let (tx, mut rx) = mpsc::channel(1);
+        seq.cmds.lock().await.insert("gen".to_string(), tx);
+        let details = crate::RateLimitErrorDetails {
+            cause: "rate_limited".into(),
+            enforcement_mode: "enforced".into(),
+            rpm_limit: 60,
+            rpm_remaining: 0,
+            tpm_limit: 100_000,
+            tpm_remaining: -1,
+            retry_after_ms: 1_000,
+        };
+
+        seq.on_event(&MSEvent::Error {
+            cid: Some("gen".into()),
+            seq_id: Some("seq-1".into()),
+            message: "Rate limit exceeded".into(),
+            code: Some("rate_limit_exceeded".into()),
+            rate_limit: Some(details.clone()),
+        })
+        .await;
+
+        match rx.recv().await.unwrap() {
+            Err(ModelSocketError::RateLimit {
+                code,
+                details: actual,
+                ..
+            }) => {
+                assert_eq!(code, "rate_limit_exceeded");
+                assert_eq!(actual, details);
+            }
+            other => panic!("expected structured rate-limit error, got {other:?}"),
+        }
     }
 }

--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -123,13 +123,13 @@ impl Seq {
                 cid,
                 message,
                 code,
-                rate_limit,
+                details,
                 ..
             } => {
                 if let Some(cid) = cid {
-                    self.on_command_error(cid, message, code, rate_limit).await;
+                    self.on_command_error(cid, message, code, details).await;
                 } else {
-                    self.on_seq_error(message, code, rate_limit).await;
+                    self.on_seq_error(message, code, details).await;
                 }
             }
             _ => {
@@ -245,12 +245,9 @@ impl Seq {
         cid: &str,
         message: &str,
         code: &Option<String>,
-        rate_limit: &Option<crate::RateLimitErrorDetails>,
+        details: &Option<serde_json::Map<String, serde_json::Value>>,
     ) {
-        let err = || {
-            super::remote_error(message, code, rate_limit)
-                .unwrap_or_else(|| ModelSocketError::Command(message.to_string()))
-        };
+        let err = || super::remote_error(message, code, details);
 
         let cmd = self.cmds.lock().await.remove(cid);
         let gen_stream = self.gen_streams.lock().await.remove(cid);
@@ -273,12 +270,9 @@ impl Seq {
         &mut self,
         message: &str,
         code: &Option<String>,
-        rate_limit: &Option<crate::RateLimitErrorDetails>,
+        details: &Option<serde_json::Map<String, serde_json::Value>>,
     ) {
-        let err = || {
-            super::remote_error(message, code, rate_limit)
-                .unwrap_or_else(|| ModelSocketError::Command(message.to_string()))
-        };
+        let err = || super::remote_error(message, code, details);
 
         let cmds = std::mem::take(&mut *self.cmds.lock().await);
         let gen_streams = std::mem::take(&mut *self.gen_streams.lock().await);
@@ -682,11 +676,15 @@ mod tests {
         }
     }
 
-    fn assert_command_error<T>(result: Result<T, ModelSocketError>, message: &str) {
+    fn assert_remote_error<T>(result: Result<T, ModelSocketError>, message: &str) {
         match result {
-            Err(ModelSocketError::Command(error)) => assert_eq!(error, message),
-            Err(error) => panic!("expected command error, got {error:?}"),
-            Ok(_) => panic!("expected command error, got ok"),
+            Err(ModelSocketError::Remote {
+                message: error,
+                code: None,
+                details: None,
+            }) => assert_eq!(error, message),
+            Err(error) => panic!("expected remote error, got {error:?}"),
+            Ok(_) => panic!("expected remote error, got ok"),
         }
     }
 
@@ -725,25 +723,25 @@ mod tests {
             seq_id: Some("seq-1".to_string()),
             message: message.to_string(),
             code: None,
-            rate_limit: None,
+            details: None,
         })
         .await;
 
-        assert_command_error(
+        assert_remote_error(
             timeout(Duration::from_millis(100), cmd_rx.recv())
                 .await
                 .expect("cmd error should be sent")
                 .expect("cmd channel should remain open"),
             message,
         );
-        assert_command_error(
+        assert_remote_error(
             timeout(Duration::from_millis(100), gen_rx.recv())
                 .await
                 .expect("gen error should be sent")
                 .expect("gen channel should remain open"),
             message,
         );
-        assert_command_error(
+        assert_remote_error(
             timeout(Duration::from_millis(100), embed_rx.recv())
                 .await
                 .expect("embed error should be sent")
@@ -757,7 +755,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn command_error_preserves_rate_limit_details() {
+    async fn command_error_preserves_remote_details() {
         let mut seq = Seq::new(
             "seq-1".to_string(),
             "model".to_string(),
@@ -767,35 +765,36 @@ mod tests {
         );
         let (tx, mut rx) = mpsc::channel(1);
         seq.cmds.lock().await.insert("gen".to_string(), tx);
-        let details = crate::RateLimitErrorDetails {
-            cause: "rate_limited".into(),
-            enforcement_mode: "enforced".into(),
-            rpm_limit: 60,
-            rpm_remaining: 0,
-            tpm_limit: 100_000,
-            tpm_remaining: -1,
-            retry_after_ms: 1_000,
-        };
+        let details = serde_json::json!({
+            "rpm_limit": 60,
+            "rpm_remaining": 0,
+            "tpm_limit": 100_000,
+            "tpm_remaining": -1,
+            "retry_after_ms": 1_000
+        })
+        .as_object()
+        .unwrap()
+        .clone();
 
         seq.on_event(&MSEvent::Error {
             cid: Some("gen".into()),
             seq_id: Some("seq-1".into()),
             message: "Rate limit exceeded".into(),
             code: Some("rate_limit_exceeded".into()),
-            rate_limit: Some(details.clone()),
+            details: Some(details.clone()),
         })
         .await;
 
         match rx.recv().await.unwrap() {
-            Err(ModelSocketError::RateLimit {
+            Err(ModelSocketError::Remote {
                 code,
                 details: actual,
                 ..
             }) => {
-                assert_eq!(code, "rate_limit_exceeded");
-                assert_eq!(actual, details);
+                assert_eq!(code.as_deref(), Some("rate_limit_exceeded"));
+                assert_eq!(actual, Some(details));
             }
-            other => panic!("expected structured rate-limit error, got {other:?}"),
+            other => panic!("expected structured remote error, got {other:?}"),
         }
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -135,20 +135,8 @@ pub enum MSEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         code: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        rate_limit: Option<RateLimitErrorDetails>,
+        details: Option<serde_json::Map<String, serde_json::Value>>,
     },
-}
-
-/// Structured rate-limit state attached to a ModelSocket error.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct RateLimitErrorDetails {
-    pub cause: String,
-    pub enforcement_mode: String,
-    pub rpm_limit: u32,
-    pub rpm_remaining: i64,
-    pub tpm_limit: u32,
-    pub tpm_remaining: i64,
-    pub retry_after_ms: u64,
 }
 
 impl MSEvent {
@@ -380,8 +368,8 @@ pub struct SeqToolCall {
 #[cfg(test)]
 mod tests {
     use super::{
-        MSEvent, RateLimitErrorDetails, SeqAppendMedia, SeqAppendReq, SeqCommand, SeqToolCall,
-        SeqToolReturnReq, ToolResult,
+        MSEvent, SeqAppendMedia, SeqAppendReq, SeqCommand, SeqToolCall, SeqToolReturnReq,
+        ToolResult,
     };
 
     #[test]
@@ -401,25 +389,27 @@ mod tests {
             old,
             MSEvent::Error {
                 code: None,
-                rate_limit: None,
+                details: None,
                 ..
             }
         ));
 
+        let details = serde_json::json!({
+            "rpm_limit": 60,
+            "rpm_remaining": 0,
+            "tpm_limit": 100_000,
+            "tpm_remaining": -5,
+            "retry_after_ms": 1_000
+        })
+        .as_object()
+        .unwrap()
+        .clone();
         let event = MSEvent::Error {
             cid: Some("gen".into()),
             seq_id: Some("seq_1".into()),
             message: "Rate limit exceeded".into(),
             code: Some("rate_limit_exceeded".into()),
-            rate_limit: Some(RateLimitErrorDetails {
-                cause: "rate_limited".into(),
-                enforcement_mode: "enforced".into(),
-                rpm_limit: 60,
-                rpm_remaining: 0,
-                tpm_limit: 100_000,
-                tpm_remaining: -5,
-                retry_after_ms: 1_000,
-            }),
+            details: Some(details),
         };
         let json = serde_json::to_string(&event).unwrap();
         let decoded: MSEvent = serde_json::from_str(&json).unwrap();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -132,7 +132,23 @@ pub enum MSEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         seq_id: Option<String>,
         message: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        rate_limit: Option<RateLimitErrorDetails>,
     },
+}
+
+/// Structured rate-limit state attached to a ModelSocket error.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RateLimitErrorDetails {
+    pub cause: String,
+    pub enforcement_mode: String,
+    pub rpm_limit: u32,
+    pub rpm_remaining: i64,
+    pub tpm_limit: u32,
+    pub tpm_remaining: i64,
+    pub retry_after_ms: u64,
 }
 
 impl MSEvent {
@@ -364,8 +380,8 @@ pub struct SeqToolCall {
 #[cfg(test)]
 mod tests {
     use super::{
-        MSEvent, SeqAppendMedia, SeqAppendReq, SeqCommand, SeqToolCall, SeqToolReturnReq,
-        ToolResult,
+        MSEvent, RateLimitErrorDetails, SeqAppendMedia, SeqAppendReq, SeqCommand, SeqToolCall,
+        SeqToolReturnReq, ToolResult,
     };
 
     #[test]
@@ -376,6 +392,41 @@ mod tests {
         assert_eq!(call.id, None);
         assert_eq!(call.name, "search");
         assert_eq!(call.args, r#"{"q":"hello"}"#);
+    }
+
+    #[test]
+    fn error_details_are_backward_compatible() {
+        let old: MSEvent = serde_json::from_str(r#"{"event":"error","message":"nope"}"#).unwrap();
+        assert!(matches!(
+            old,
+            MSEvent::Error {
+                code: None,
+                rate_limit: None,
+                ..
+            }
+        ));
+
+        let event = MSEvent::Error {
+            cid: Some("gen".into()),
+            seq_id: Some("seq_1".into()),
+            message: "Rate limit exceeded".into(),
+            code: Some("rate_limit_exceeded".into()),
+            rate_limit: Some(RateLimitErrorDetails {
+                cause: "rate_limited".into(),
+                enforcement_mode: "enforced".into(),
+                rpm_limit: 60,
+                rpm_remaining: 0,
+                tpm_limit: 100_000,
+                tpm_remaining: -5,
+                retry_after_ms: 1_000,
+            }),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let decoded: MSEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            serde_json::to_value(decoded).unwrap(),
+            serde_json::to_value(event).unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Right now `SeqError` just returns an error message - we should have something more strictly structured/reliable. We also want to be able to pass additional detail about an error - such as for a rate limiting error, how many RPM/TPM have been consumed and what's remaining. Here, we `code` and `details`, which are generic but for now are specifically designed to handle the rate limiting case.

Backwards compatibility is retained - both fields are optional and omitted when absent.

Example error payload:

```json
{
  "event": "error",
  "cid": "gen_01JABC123",
  "seq_id": "seq_01JXYZ789",
  "message": "Rate limit exceeded",
  "code": "rate_limit_exceeded",
  "details": {
    "rpm_limit": 60,
    "rpm_remaining": 0,
    "tpm_limit": 100000,
    "tpm_remaining": 42000,
    "retry_after_ms": 1000
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote errors now preserve optional error codes and structured details, making failures easier to understand and handle.
  * Connection, command, streaming, and embedding errors consistently expose the available remote error information.

* **Bug Fixes**
  * Improved error propagation so details are not lost during connection or command failures.
  * Existing error messages without codes or details remain fully compatible.

* **Release**
  * Updated the package version to 0.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->