### PR TITLE
Add stop reason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "modelsocket"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -53,6 +53,8 @@ pub enum MSEvent {
     SeqGenFinish {
         seq_id: String,
         cid: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        stop_reason: Option<SeqStopReason>,
     },
     SeqEmbedding {
         seq_id: String,
@@ -133,6 +135,21 @@ pub enum MSEvent {
         seq_id: Option<String>,
         message: String,
     },
+}
+
+/// Why model generation stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SeqStopReason {
+    /// The model emitted its end-of-sequence token.
+    Eos,
+    /// The requested generation token limit was reached.
+    MaxTokens,
+    /// A caller-provided stop string was encountered.
+    StopText,
+    /// The server reported a stop reason this client does not recognize.
+    #[serde(other)]
+    Unknown,
 }
 
 impl MSEvent {


### PR DESCRIPTION
Right now a stop based on `max_tokens` does not return the proper stop reason - we just report a gen `stop`, when we should actually be reporting `length`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generation-completion events now optionally report why generation stopped: end of sequence, maximum token limit, stop text, or an unknown reason.
  - Existing integrations remain compatible when no stop reason is provided.
- **Release**
  - Updated the package version to 0.5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->