### PR TITLE
Pass cid/seq_id as structured meta instead of as a value in the errors

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -247,7 +247,7 @@ impl ModelSocketEventHandler {
                 error!("failed to send seq_id: {}", e);
             }
         } else {
-            error!("unknown opened seq cid {}", cid);
+            error!(cid, "unknown opened seq cid");
         }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -207,7 +207,7 @@ impl ModelSocketEventHandler {
         if let Some(seq) = seqs.get_mut(seq_id) {
             seq.on_event(event).await;
         } else {
-            error!("state error: unknown seq_id {}", seq_id);
+            error!(seq_id, "state error: unknown seq_id");
         }
     }
 


### PR DESCRIPTION
There's probably a few others that we should consider doing the same for, but `unknown seq_id` is the bulk of the unnormalised noise we see.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved diagnostic logging for unmatched sequence IDs and callback identifiers using structured fields.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->