### PR TITLE
Add max_emitted_tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "modelsocket"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -351,6 +351,7 @@ pub struct GenOpts {
     pub json_schema_strict: Option<bool>,
     pub frequency_penalty: Option<f32>,
     pub presence_penalty: Option<f32>,
+    pub max_emitted_tools: Option<u32>,
 }
 
 impl GenOpts {
@@ -393,6 +394,7 @@ impl Into<SeqGenReq> for GenOpts {
             json_schema_strict: self.json_schema_strict,
             frequency_penalty: self.frequency_penalty,
             presence_penalty: self.presence_penalty,
+            max_emitted_tools: self.max_emitted_tools,
             ..Default::default()
         }
     }

--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -37,6 +37,9 @@ pub struct Seq {
     /// open gen streams waiting for a response and their return channels
     gen_streams: Arc<Mutex<HashMap<String, mpsc::Sender<Result<GenChunk, ModelSocketError>>>>>,
 
+    /// options for the active generation leg, reused by automatic tool returns
+    active_gen_opts: Arc<Mutex<SeqGenReq>>,
+
     /// open embedding commands waiting for a complete batch response
     embed_cmds: Arc<Mutex<HashMap<String, EmbedCommandState>>>,
 
@@ -61,6 +64,7 @@ impl Seq {
             socket,
             cmds: Arc::new(Mutex::new(HashMap::new())),
             gen_streams: Arc::new(Mutex::new(HashMap::new())),
+            active_gen_opts: Arc::new(Mutex::new(SeqGenReq::default())),
             embed_cmds: Arc::new(Mutex::new(HashMap::new())),
             event_tx,
             toolbox,
@@ -330,7 +334,7 @@ impl Seq {
                     seq_id: self.seq_id.clone(),
                     data: SeqCommand::ToolReturn(SeqToolReturnReq {
                         results,
-                        gen_opts: Default::default(), //TODO resume generating with the same options
+                        gen_opts: self.active_gen_opts.lock().await.clone(),
                     }),
                 };
 
@@ -355,6 +359,10 @@ impl Seq {
         cid: S,
         cmd: SeqCommand,
     ) -> Result<(), ModelSocketError> {
+        if let SeqCommand::Gen(gen_opts) = &cmd {
+            *self.active_gen_opts.lock().await = gen_opts.clone();
+        }
+
         self.socket
             .send_request(MSRequest::SeqCommand {
                 cid: cid.as_ref().to_string(),
@@ -433,11 +441,14 @@ impl Seq {
         let (stream_tx, stream_rx) = mpsc::channel(100);
         self.gen_streams.lock().await.insert(cid.clone(), stream_tx);
 
+        let gen_opts = opts.map(Into::into).unwrap_or_default();
+        *self.active_gen_opts.lock().await = gen_opts.clone();
+
         self.socket
             .send_request(MSRequest::SeqCommand {
                 cid: cid.clone(),
                 seq_id: self.seq_id.clone(),
-                data: SeqCommand::Gen(opts.map(|o| o.into()).unwrap_or_default()),
+                data: SeqCommand::Gen(gen_opts),
             })
             .await?;
 
@@ -629,6 +640,9 @@ pub struct EmbeddingResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ToolResult;
+    use anyhow::Result;
+    use async_trait::async_trait;
     use futures::Sink;
     use std::task::{Context, Poll};
     use tokio::time::{timeout, Duration};
@@ -664,6 +678,29 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct TestToolbox;
+
+    #[async_trait]
+    impl Toolbox for TestToolbox {
+        async fn call_tools(&self, calls: &[SeqToolCall]) -> Result<Option<Vec<ToolResult>>> {
+            Ok(Some(
+                calls
+                    .iter()
+                    .map(|call| ToolResult {
+                        id: call.id.clone(),
+                        name: call.name.clone(),
+                        result: "ok".to_string(),
+                    })
+                    .collect(),
+            ))
+        }
+
+        fn tool_def_prompt(&self) -> Option<String> {
+            None
+        }
+    }
+
     fn test_socket() -> ModelSocket {
         let ws_sink: Pin<Box<dyn Sink<MSRequest, Error = ModelSocketError> + Send>> =
             Box::pin(RequestSink);
@@ -673,6 +710,87 @@ mod tests {
             opening_seqs: Default::default(),
             seqs: Default::default(),
             closed_seqs: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn automatic_tool_return_preserves_generation_options() {
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let ws_sink: Pin<Box<dyn Sink<MSRequest, Error = ModelSocketError> + Send>> =
+            Box::pin(CapturingRequestSink(request_tx));
+        let mut seq = Seq::new(
+            "seq-1".to_string(),
+            "model".to_string(),
+            ModelSocket {
+                ws_sink: Arc::new(Mutex::new(ws_sink)),
+                opening_seqs: Default::default(),
+                seqs: Default::default(),
+                closed_seqs: Default::default(),
+            },
+            Arc::new(Some(Mutex::new(Box::new(TestToolbox)))),
+            None,
+        );
+        seq.send_cmd(
+            "gen",
+            SeqCommand::Gen(SeqGenReq {
+                max_emitted_tools: Some(1),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        let _ = request_rx.recv().await.unwrap();
+
+        seq.on_tool_call(
+            "gen",
+            &vec![SeqToolCall {
+                id: Some("call-1".to_string()),
+                name: "search".to_string(),
+                args: "{}".to_string(),
+            }],
+        )
+        .await;
+
+        let MSRequest::SeqCommand {
+            data: SeqCommand::ToolReturn(request),
+            ..
+        } = request_rx.recv().await.unwrap()
+        else {
+            panic!("expected tool return request");
+        };
+        assert_eq!(request.gen_opts.max_emitted_tools, Some(1));
+    }
+
+    struct CapturingRequestSink(mpsc::UnboundedSender<MSRequest>);
+
+    impl Sink<MSRequest> for CapturingRequestSink {
+        type Error = ModelSocketError;
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn start_send(self: Pin<&mut Self>, item: MSRequest) -> Result<(), Self::Error> {
+            self.0
+                .send(item)
+                .map_err(|_| ModelSocketError::State("request receiver closed".to_string()))
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
         }
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -335,6 +335,8 @@ pub struct SeqGenReq {
     pub frequency_penalty: Option<f32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub presence_penalty: Option<f32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_emitted_tools: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This will provide `parallel_tool_calls: true|false` (OpenAI) like functionality for ModelSocket, where the number of tool calls in a single turn that the model will emit can be limited.

Note this is _different_ to `max_tool_calls` in OpenAI compatible endpoints, which allows you to constrain the total number of tool calls that can be made over multiple turns. For that kind of thing, it's expected that clients (in our case, our gateway) handle that by tracking the number of tool calls over turns and then disabling tool calls when a final text return is expected.

`max_emitted_tools` is preserved between generations with tool results so the behaviour remains consistent for a single sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to limit the number of tools emitted during generation.
  * Generation requests now support carrying this setting through the request lifecycle.

* **Bug Fixes**
  * Automatic tool-return requests now preserve the active generation settings instead of reverting to defaults.

* **Release**
  * Updated the crate version to 0.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->