### PR TITLE
Add AppendParts for carrying multi-part/structured turns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "modelsocket"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modelsocket"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 description = "A Rust library for ModelSocket, a protocol for efficiently integrating with LLMs"
 license = "Apache-2.0"

--- a/src/client/seq.rs
+++ b/src/client/seq.rs
@@ -1,7 +1,7 @@
 use crate::{
     protocol::{
-        EmbeddingInput, MSEvent, MSRequest, SeqAppendMedia, SeqAppendReq, SeqCloseReq, SeqCommand,
-        SeqEmbedReq, SeqForkReq, SeqGenReq,
+        EmbeddingInput, MSEvent, MSRequest, SeqAppendMedia, SeqAppendPart, SeqAppendPartsReq,
+        SeqAppendReq, SeqCloseReq, SeqCommand, SeqEmbedReq, SeqForkReq, SeqGenReq,
     },
     tools::Toolbox,
     SeqToolCall, SeqToolReturnReq,
@@ -430,6 +430,36 @@ impl Seq {
         Ok(())
     }
 
+    /// Appends ordered text, token, and media parts in one prefill operation.
+    pub async fn append_parts(
+        &self,
+        parts: Vec<SeqAppendPart>,
+        opts: AppendOpts,
+    ) -> Result<(), ModelSocketError> {
+        let cid = Uuid::new_v4().to_string();
+        let (tx, mut rx) = mpsc::channel(1);
+        self.cmds.lock().await.insert(cid.clone(), tx);
+
+        self.socket
+            .send_request(MSRequest::SeqCommand {
+                cid: cid.clone(),
+                seq_id: self.seq_id.clone(),
+                data: SeqCommand::AppendParts(SeqAppendPartsReq {
+                    parts,
+                    hidden: false,
+                    echo: false,
+                    role: opts.role,
+                }),
+            })
+            .await?;
+
+        rx.recv()
+            .await
+            .ok_or_else(|| ModelSocketError::Command("failed to receive response".into()))??;
+
+        Ok(())
+    }
+
     pub async fn generate<O: Into<SeqGenReq>>(
         &self,
         opts: Option<O>,
@@ -759,6 +789,66 @@ mod tests {
             panic!("expected tool return request");
         };
         assert_eq!(request.gen_opts.max_emitted_tools, Some(1));
+    }
+
+    #[tokio::test]
+    async fn append_parts_sends_ordered_parts_and_waits_for_completion() {
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
+        let ws_sink: Pin<Box<dyn Sink<MSRequest, Error = ModelSocketError> + Send>> =
+            Box::pin(CapturingRequestSink(request_tx));
+        let seq = Seq::new(
+            "seq-1".to_string(),
+            "model".to_string(),
+            ModelSocket {
+                ws_sink: Arc::new(Mutex::new(ws_sink)),
+                opening_seqs: Default::default(),
+                seqs: Default::default(),
+                closed_seqs: Default::default(),
+            },
+            Arc::new(None),
+            None,
+        );
+        let mut event_seq = seq.clone();
+
+        let append = tokio::spawn(async move {
+            seq.append_parts(
+                vec![
+                    SeqAppendPart::Text("before".to_string()),
+                    SeqAppendPart::Tokens(vec![1, 2]),
+                    SeqAppendPart::Text("after".to_string()),
+                ],
+                AppendOpts {
+                    role: Some("user".to_string()),
+                },
+            )
+            .await
+        });
+
+        let MSRequest::SeqCommand { cid, seq_id, data } = request_rx.recv().await.unwrap() else {
+            panic!("expected sequence command");
+        };
+        let SeqCommand::AppendParts(request) = data else {
+            panic!("expected append-parts command");
+        };
+        assert_eq!(seq_id, "seq-1");
+        assert_eq!(request.role.as_deref(), Some("user"));
+        assert!(matches!(
+            &request.parts[..],
+            [
+                SeqAppendPart::Text(before),
+                SeqAppendPart::Tokens(tokens),
+                SeqAppendPart::Text(after),
+            ] if before == "before" && tokens == &[1, 2] && after == "after"
+        ));
+        assert!(!append.is_finished());
+
+        event_seq
+            .on_event(&MSEvent::SeqAppendFinish {
+                seq_id: "seq-1".to_string(),
+                cid,
+            })
+            .await;
+        append.await.unwrap().unwrap();
     }
 
     struct CapturingRequestSink(mpsc::UnboundedSender<MSRequest>);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -27,6 +27,7 @@ pub enum MSRequest {
 pub enum SeqCommand {
     Close(SeqCloseReq),
     Append(SeqAppendReq),
+    AppendParts(SeqAppendPartsReq),
     Gen(SeqGenReq),
     Embed(SeqEmbedReq),
     ToolReturn(SeqToolReturnReq),
@@ -248,7 +249,30 @@ pub struct SeqAppendReq {
     #[serde(default)]
     pub echo: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Switches roles when needed; repeating the current role continues it.
     pub role: Option<String>,
+}
+
+/// Appends ordered text, token, and media parts as one sequence prefill operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeqAppendPartsReq {
+    pub parts: Vec<SeqAppendPart>,
+    #[serde(default)]
+    pub hidden: bool,
+    #[serde(default)]
+    pub echo: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Starts a new role block unconditionally; `None` continues the current block.
+    pub role: Option<String>,
+}
+
+/// One ordered part in a sequence append-parts request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SeqAppendPart {
+    Text(String),
+    Tokens(Vec<u32>),
+    Media(SeqAppendMedia),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -398,8 +422,9 @@ pub struct SeqToolCall {
 #[cfg(test)]
 mod tests {
     use super::{
-        EmbeddingContentPart, EmbeddingInput, MSEvent, SeqAppendMedia, SeqAppendReq, SeqCommand,
-        SeqEmbedReq, SeqToolCall, SeqToolReturnReq, ToolResult,
+        EmbeddingContentPart, EmbeddingInput, MSEvent, SeqAppendMedia, SeqAppendPart,
+        SeqAppendPartsReq, SeqAppendReq, SeqCommand, SeqEmbedReq, SeqToolCall, SeqToolReturnReq,
+        ToolResult,
     };
     use serde_json::{json, Value};
 
@@ -554,6 +579,43 @@ mod tests {
 
         assert_eq!(media.blob.as_deref(), Some("aW1hZ2U="));
         assert_eq!(media.detail.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn append_parts_command_preserves_text_media_text_order() {
+        let cmd = SeqCommand::AppendParts(SeqAppendPartsReq {
+            parts: vec![
+                SeqAppendPart::Text("before".to_string()),
+                SeqAppendPart::Media(SeqAppendMedia {
+                    uri: Some("https://example.com/cat.png".to_string()),
+                    blob: None,
+                    hash: Some("b3abc".to_string()),
+                    mime_type: Some("image/png".to_string()),
+                    detail: Some("auto".to_string()),
+                }),
+                SeqAppendPart::Text("after".to_string()),
+            ],
+            hidden: false,
+            echo: false,
+            role: Some("user".to_string()),
+        });
+
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains(r#""command":"append_parts""#));
+
+        let parsed: SeqCommand = serde_json::from_str(&json).unwrap();
+        let SeqCommand::AppendParts(parsed) = parsed else {
+            panic!("expected append-parts command");
+        };
+        assert_eq!(parsed.role.as_deref(), Some("user"));
+        assert!(matches!(
+            &parsed.parts[..],
+            [
+                SeqAppendPart::Text(before),
+                SeqAppendPart::Media(_),
+                SeqAppendPart::Text(after)
+            ] if before == "before" && after == "after"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
This adds a new `AppendParts` command to the protocol It lets you in a single append call pass multiple parts:

```
AppendParts:
  role: user
  parts:
    - type: text
      text: What colour is the delivery van in
    - type: media
      media:
        uri: https://www.example.com/van.jpeg
        mime_type: image/jpeg
        detail: auto
    - type: text
      text: ? Answer briefly.
```

`role` will cause a role transition - even if you pass the same role in two sequential calls. If you want to append to the existing role's turn, pass an empty `role:`.

This is part of a broader/internal initiative which changes how we pass turns/appends over the wire and is needed because of our shared consumption of modelsocket for the internal of the Mixlayer platform.